### PR TITLE
Add statistics for normal, exp and discete uniform, fix issue #75

### DIFF
--- a/demos/adapt_pce.py
+++ b/demos/adapt_pce.py
@@ -76,8 +76,7 @@ Nstarting_samples = pce.samples.shape[0]
 initial_accuracy = pce.accuracy_metrics.copy()
 
 # pce.adapt_robustness(max_new_samples=50)
-residuals, loocvs, added_indices, added_samples = \
-        pce.adapt_expressivity(max_new_samples=100, add_rule=3)
+residuals, loocvs, added_indices, added_samples = pce.adapt_expressivity(max_new_samples=100, add_rule=3)
 
 # # Postprocess PCE: mean, stdev, sensitivities, quantiles
 mean = pce.mean()

--- a/demos/build_pce_normal.py
+++ b/demos/build_pce_normal.py
@@ -73,6 +73,8 @@ total_sensitivity = pce.total_sensitivity()
 # "Global sensitivity" is a partitive relative sensitivity measure per set of parameters.
 global_sensitivity = pce.global_sensitivity(variable_interactions)
 
+
+
 Q = 4  # Number of quantile bands to plot
 dq = 0.5/(Q+1)
 q_lower = np.arange(dq, 0.5-1e-7, dq)[::-1]
@@ -160,4 +162,36 @@ ax.pie(average_global_SI*100, labels=labels, autopct='%1.1f%%',
 ax.axis('equal')  # Equal aspect ratio ensures that pie is drawn as a circle.
 plt.title('Sensitivity due to variable interactions')
 
+
+
+
+
+sensitivities = [total_sensitivity, global_sensitivity]
+
+sensbounds = [[0, 1], [0, 1]]
+
+senslabels = ['Total sensitivity', 'Global sensitivity']
+dimlabels = ['Dimension 1', 'Dimension 2', 'Interaction']
+
+fig, ax = plt.subplots(2, 3)
+for row in range(2):
+    for col in range(2):
+        ax[row][col].plot(x, sensitivities[row][col,:])
+        ax[row][col].set_ylim(sensbounds[row])
+        if row==2:
+            ax[row][col].set(xlabel='$x$')
+        if col==0:
+            ax[row][col].set(ylabel=senslabels[row])
+        if row==0:
+            ax[row][col].set_title(dimlabels[col])
+        if row<2:
+            ax[row][col].xaxis.set_ticks([])
+        if col>0:
+            ax[row][col].yaxis.set_ticks([])
+  
+ax[1][2].plot(x, sensitivities[1][2,:])
+ax[1][2].set_ylim(sensbounds[1])
+
+
 plt.show()
+

--- a/demos/simple_discrete_uniform_distribution.py
+++ b/demos/simple_discrete_uniform_distribution.py
@@ -1,6 +1,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
 
 from UncertainSCI.distributions import DiscreteUniformDistribution
 

--- a/demos/simple_discrete_uniform_distribution.py
+++ b/demos/simple_discrete_uniform_distribution.py
@@ -1,0 +1,47 @@
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib import cm
+
+from UncertainSCI.distributions import DiscreteUniformDistribution
+
+
+"""
+This script demonstrates basic instantiation and manipulation of a bivariate
+discrete uniform distribution on a rectangle.
+"""
+
+dim = 2
+bounds = np.zeros([2, dim])
+
+bounds[:, 0] = [3, 5]    # Bounds for first parameter
+bounds[:, 1] = [-5, -3]  # Bounds for second parameter
+
+n = [5, 10]
+
+p = DiscreteUniformDistribution(domain=bounds, n=n)
+
+mu = p.mean()
+cov = p.cov()
+
+print("The mean of this distribution is")
+print(np.array2string(mu))
+print("\nThe covariance matrix of this distribution is")
+print(np.array2string(cov))
+
+
+x = np.linspace(bounds[0, 0], bounds[1, 0], n[0])
+y = np.linspace(bounds[0, 1], bounds[1, 1], n[1])
+
+X, Y = np.meshgrid(x, y)
+XY = np.vstack([X.flatten(), Y.flatten()]).T
+
+pmf = p.pmf(XY)
+# Reshape for plotting
+pmf = np.reshape(pmf, [n[0], n[1]])
+
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+surf = ax.scatter(X, Y, pmf, cmap=cm.coolwarm)
+fig.colorbar(surf)
+plt.title('PDF for a bivariate discrete uniform distribution')
+
+plt.show()

--- a/demos/simple_exponential_distribution.py
+++ b/demos/simple_exponential_distribution.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
 
 from UncertainSCI.distributions import ExponentialDistribution
 

--- a/demos/simple_exponential_distribution.py
+++ b/demos/simple_exponential_distribution.py
@@ -1,0 +1,38 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import cm
+
+from UncertainSCI.distributions import ExponentialDistribution
+
+dim = 2
+lbd = np.array([1, 2])
+loc = np.array([0, 1])
+
+p = ExponentialDistribution(lbd=lbd, loc=loc)
+
+mu = p.mean()
+cov = p.cov()
+
+print("The mean of this distribution is")
+print(np.array2string(mu))
+print("\nThe covariance matrix of this distribution is")
+print(np.array2string(cov))
+
+# Create a grid to plot the density
+M = 100
+x = np.linspace(loc[0], 5, M)
+y = np.linspace(loc[1], 5, M)
+
+X, Y = np.meshgrid(x, y)
+XY = np.vstack([X.flatten(), Y.flatten()]).T
+
+pdf = p.pdf(XY)
+# Reshape for plotting
+pdf = np.reshape(pdf, [M, M])
+
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+surf = ax.plot_surface(X, Y, pdf, cmap=cm.coolwarm)
+fig.colorbar(surf)
+plt.title('PDF for a bivariate Exponential distribution')
+
+plt.show()

--- a/demos/simple_normal_distribution.py
+++ b/demos/simple_normal_distribution.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
 
 from UncertainSCI.distributions import NormalDistribution
 from scipy.stats import multivariate_normal

--- a/demos/simple_normal_distribution.py
+++ b/demos/simple_normal_distribution.py
@@ -11,10 +11,10 @@ dim = 2
 mean = np.array([0, 0])
 cov = np.array([[1, 0], [0, 5]])
 
-p = NormalDistribution(mean=mean, cov=cov)
+p = NormalDistribution(_mean=mean, _cov=cov)
 
-mu = p.mean
-cov = p.cov
+mu = p.mean()
+cov = p.cov()
 
 print("The mean of this distribution is")
 print(np.array2string(mu))

--- a/demos/simple_normal_distribution.py
+++ b/demos/simple_normal_distribution.py
@@ -1,0 +1,47 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import cm
+
+from UncertainSCI.distributions import NormalDistribution
+from scipy.stats import multivariate_normal
+
+
+dim = 2
+mean = np.array([0, 0])
+cov = np.array([[1, 0], [0, 5]])
+
+p = NormalDistribution(mean=mean, cov=cov)
+
+mu = p.mean
+cov = p.cov
+
+print("The mean of this distribution is")
+print(np.array2string(mu))
+print("\nThe covariance matrix of this distribution is")
+print(np.array2string(cov))
+
+# Create a grid to plot the density
+M = 100
+x = np.linspace(-5, 5, M)
+y = np.linspace(-5, 5, M)
+
+X, Y = np.meshgrid(x, y)
+XY = np.vstack([X.flatten(), Y.flatten()]).T
+
+pdf = p.pdf(XY)
+# Reshape for plotting
+pdf = np.reshape(pdf, [M, M])
+
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+surf = ax.plot_surface(X, Y, pdf, cmap=cm.coolwarm)
+fig.colorbar(surf)
+plt.title('PDF for a bivariate normal distribution')
+
+plt.show()
+
+# x, y = np.random.multivariate_normal(mean, cov, M).T
+# xx = np.random.multivariate_normal(mean, cov, M)
+var = multivariate_normal(mean=mean, cov=cov)
+true_pdf = var.pdf(XY).reshape([M, M])
+print("The error of pdf is")
+print(np.linalg.norm(pdf - true_pdf))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ certifi==2020.4.5.1
 cycler==0.10.0
 kiwisolver==1.2.0
 matplotlib==3.1.3
-numpy==1.17.2
+numpy==1.15.2; python_version < '3.8'
+numpy==1.17.2; python_version >= '3.8'
 packaging==20.3
 pyparsing==2.4.7
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ certifi==2020.4.5.1
 cycler==0.10.0
 kiwisolver==1.2.0
 matplotlib==3.1.3
-numpy==1.15.2; python_version < '3.8'
-numpy==1.17.2; python_version >= '3.8'
+numpy==1.17.2
 packaging==20.3
 pyparsing==2.4.7
 python-dateutil==2.8.1


### PR DESCRIPTION
Add mean, cov and pdf (pmf for discrete uniform) for distributions.
Please run simple_normal_distribution.py, simple_exponential_distribution.py, and simple_discrete_uniform_distribution.py in demo/ to check the results and figures.