### PR TITLE
Numpy 2 Updates

### DIFF
--- a/UncertainSCI/families.py
+++ b/UncertainSCI/families.py
@@ -81,14 +81,9 @@ def jacobi_recurrence_values(N, alpha, beta):
 
 
 def jacobi_idist_driver(x, n, alpha, beta, M):
-
     A = int(np.floor(np.abs(alpha)))
     Aa = alpha - A
-
-    if isinstance(x, float) or isinstance(x, int):
-        x = np.asarray([x])
-    else:
-        x = np.asarray(x)
+    x = np.atleast_1d(x)
 
     F = np.zeros(x.size)
 
@@ -142,11 +137,7 @@ def jacobi_idist_driver(x, n, alpha, beta, M):
 
 
 def fidistinv_setup_helper1(ug, exps):
-
-    if isinstance(ug, float) or isinstance(ug, int):
-        ug = np.asarray([ug])
-    else:
-        ug = np.asarray(ug)
+    ug = np.atleast_1d(ug)
 
     ug_mid = 1/2 * (ug[:-1] + ug[1:])
     ug = np.sort(np.append(ug, ug_mid))
@@ -211,16 +202,8 @@ def fidistinv_setup_helper2(ug, idistinv, exponents, M, alpha, beta):
 
 
 def fidistinv_driver(u, n, data):
-
-    if isinstance(u, float) or isinstance(u, int):
-        u = np.asarray([u])
-    else:
-        u = np.asarray(u)
-
-    if isinstance(n, float) or isinstance(n, int):
-        n = np.asarray([n])
-    else:
-        n = np.asarray(n)
+    u = np.atleast_1d(u)
+    n = np.atleast_1d(n)
 
     if u.size == 0:
         return np.zeros(0)
@@ -228,12 +211,12 @@ def fidistinv_driver(u, n, data):
     if n.size != 1:
         assert u.size == n.size  # Inputs u and n must be the same size, or n must be a scalar
 
-    N = max(n)
+    N = int(max(n))
     assert len(data) >= N+1  # Input data does not cover range of n
 
     x = np.zeros(u.size)
     if n.size == 1:
-        x = driver_helper(u, data[int(n)])
+        x = driver_helper(u, data[int(n[0])])
     else:
         for q in range(N+1):
             nmask = (n == q)
@@ -243,7 +226,6 @@ def fidistinv_driver(u, n, data):
 
 
 def driver_helper(u, data):
-
     tol = 1e-12
 
     M = data.shape[0] - 6
@@ -325,10 +307,7 @@ class JacobiPolynomials(OrthogonalPolynomialBasis1D):
         Computes the order-n induced distribution at the locations x using M=10
         quadrature nodes.
         """
-        if isinstance(x, float) or isinstance(x, int):
-            x = np.asarray([x])
-        else:
-            x = np.asarray(x)
+        x = np.atleast_1d(x)
 
         F = np.zeros(x.size, )
         mrs_centroid = self.idist_medapprox(n)
@@ -338,24 +317,17 @@ class JacobiPolynomials(OrthogonalPolynomialBasis1D):
         return F
 
     def idistinv(self, u, n):
-
-        if isinstance(u, float) or isinstance(u, int):
-            u = np.asarray([u])
-        else:
-            u = np.asarray(u)
+        u = np.atleast_1d(u)
 
         x = np.zeros(u.size)
         supp = [-1, 1]
 
-        if isinstance(n, float) or isinstance(n, int):
-            n = np.asarray([n])
-        else:
-            n = np.asarray(n)
+        n = np.atleast_1d(n)
 
         M = 10
 
         if n.size == 1:
-            n = int(n)
+            n = int(n[0])
 
             def primitive(xx):
                 return self.idist(xx, n, M=M)
@@ -364,8 +336,7 @@ class JacobiPolynomials(OrthogonalPolynomialBasis1D):
             x = idistinv_driver(u, n, primitive, ab, supp)
 
         else:
-
-            nmax = np.amax(n)
+            nmax = int(np.amax(n))
             ind = np.digitize(n, np.arange(-0.5, 0.5+nmax+1e-8), right=False)
 
             ab = self.recurrence_driver(2*nmax + M+1)
@@ -430,7 +401,6 @@ class JacobiPolynomials(OrthogonalPolynomialBasis1D):
         return data
 
     def fidistinv(self, u, n):
-
         dirName = 'data_set'
         parent_dir = os.path.dirname(os.path.dirname(uSCI.__file__))
         path = os.path.join(parent_dir, dirName)
@@ -452,15 +422,13 @@ class JacobiPolynomials(OrthogonalPolynomialBasis1D):
             with open(os.path.join(path, filename), 'ab+') as f:
                 pickle.dump(data, f)
 
-        if isinstance(n, float) or isinstance(n, int):
-            n = np.asarray([n])
-        else:
-            n = np.asarray(n)
+        n = np.atleast_1d(n)
 
-        if len(data) < max(n[:]) + 1:
+        nmax = int(max(n))
+        if len(data) < nmax + 1:
             msg = 'Precomputing data for Jacobi parameters (alpha,beta) = ({0:1.6f}, {1:1.6f})...'
             print(msg.format(self.alpha, self.beta), end='', flush=True)
-            data = self.fidistinv_jacobi_setup(max(n[:]), data)
+            data = self.fidistinv_jacobi_setup(nmax, data)
             with open(os.path.join(path, filename), 'wb') as f:
                 pickle.dump(data, f)
             print('Done', flush=True)
@@ -475,12 +443,8 @@ class JacobiPolynomials(OrthogonalPolynomialBasis1D):
         three-term recurrence coefficients ab
 
         """
-
-        n = np.asarray(n)
-        if isinstance(x, int) or isinstance(x, float):
-            x = np.asarray([x])
-        else:
-            x = np.asarray(x)
+        n = np.atleast_1d(n)
+        x = np.atleast_1d(x)
 
         if n.size < 1 or x.size < 1:
             return np.zeros(0)
@@ -510,7 +474,6 @@ class JacobiPolynomials(OrthogonalPolynomialBasis1D):
         Evaluates tensorial orthonormal polynomials associated with the
         univariate recurrence coefficients ab
         """
-
         try:
             M, d = x.shape
         except Exception:
@@ -544,11 +507,7 @@ def freud_idist(x, n, alpha, rho):
     """
     for x <= 0
     """
-
-    if isinstance(x, float) or isinstance(x, int):
-        x = np.asarray([x])
-    else:
-        x = np.asarray(x)
+    x = np.atleast_1d(x)
 
     F = np.zeros(x.size)
 
@@ -561,16 +520,8 @@ def freud_idist(x, n, alpha, rho):
 
 
 def freud_idistinv(u, n, alpha, rho):
-
-    if isinstance(u, float) or isinstance(u, int):
-        u = np.asarray([u])
-    else:
-        u = np.asarray(u)
-
-    if isinstance(n, float) or isinstance(n, int):
-        n = np.asarray([n])
-    else:
-        n = np.asarray(n)
+    u = np.atleast_1d(u)
+    n = np.atleast_1d(n)
 
     x = np.zeros(u.shape)
 
@@ -618,10 +569,7 @@ class HermitePolynomials(OrthogonalPolynomialBasis1D):
         alpha = self.alpha
         rho = self.rho
 
-        if isinstance(x, float) or isinstance(x, int):
-            x = np.asarray([x])
-        else:
-            x = np.asarray(x)
+        x = np.atleast_1d(x)
 
         F = np.zeros(x.size)
         F[np.where(x <= 0)] = freud_idist(x[np.where(x <= 0)], n, alpha, rho)
@@ -660,10 +608,7 @@ def hfreud_idist_driver(x, n, alpha, rho, M=25):
     """
     Evaluates the integral, F = \\int_{0}^x p_n^2(x) \\dx{\\mu(x)} for x <= x0
     """
-    if isinstance(x, float) or isinstance(x, int):
-        x = np.asarray([x])
-    else:
-        x = np.asarray(x)
+    x = np.atleast_1d(x)
 
     F = np.zeros(x.size)
 
@@ -727,10 +672,7 @@ def hfreud_idistc_driver(x, n, alpha, rho, M=25):
     """
     Evaluates the integral, F = \\int_{0}^x p_n^2(x) \\dx{\\mu(x)} for x >= x0
     """
-    if isinstance(x, float) or isinstance(x, int):
-        x = np.asarray([x])
-    else:
-        x = np.asarray(x)
+    x = np.atleast_1d(x)
 
     F = np.zeros(x.size)
 
@@ -784,7 +726,6 @@ def hfreud_idistc_driver(x, n, alpha, rho, M=25):
 
 
 def hfreud_idist_medapprox(n, alpha, rho):
-
     if n > 0:
         a = rho + 2*n + 2*np.sqrt(n**2 + n*rho)  # maxapprox
         a = a ** (1/alpha)
@@ -806,11 +747,7 @@ def hfreud_idist_medapprox(n, alpha, rho):
 
 
 def hfreud_idist(x, n, alpha, rho):
-
-    if isinstance(x, float) or isinstance(x, int):
-        x = np.asarray([x])
-    else:
-        x = np.asarray(x)
+    x = np.atleast_1d(x)
 
     if alpha != 1:
         x0 = sum(hfreud_idist_medapprox(n, alpha, rho)) / 2
@@ -825,7 +762,6 @@ def hfreud_idist(x, n, alpha, rho):
 
 
 def hfreud_idistc(x, n, alpha, rho):
-
     return 1 - hfreud_idist(x, n, alpha, rho)
 
 #     if isinstance(x, float) or isinstance(x, int):
@@ -858,18 +794,10 @@ def hfreud_tolerance(n, alpha, rho, tol):
 
 
 def hfreud_idistinv(u, n, alpha, rho):
-
     eps = np.finfo(float).eps
 
-    if isinstance(u, float) or isinstance(u, int):
-        u = np.asarray([u])
-    else:
-        u = np.asarray(u)
-
-    if isinstance(n, float) or isinstance(n, int):
-        n = np.asarray([n])
-    else:
-        n = np.asarray(n)
+    u = np.atleast_1d(u)
+    n = np.atleast_1d(n)
 
     if n.size == 1:
         n = n[0]
@@ -892,7 +820,7 @@ def hfreud_idistinv(u, n, alpha, rho):
 
         x = idistinv_driver(u, n, primitive, ab, supp)
     else:
-        nmax = np.amax(n)
+        nmax = int(np.amax(n))
         ind = np.digitize(n, np.arange(-0.5, 0.5+nmax+1e-8), right=False)
         ab = laguerre_recurrence_values(2*nmax + max(100, nmax), alpha, rho)
 
@@ -940,21 +868,18 @@ class LaguerrePolynomials(OrthogonalPolynomialBasis1D):
         return ab
 
     def idist_medapprox(self, n):
-
         alpha = self.alpha
         rho = self.rho
 
         return sum(hfreud_idist_medapprox(n, alpha, rho)) / 2
 
     def idist(self, x, n):
-
         alpha = self.alpha
         rho = self.rho
 
         return hfreud_idist(x, n, alpha, rho)
 
     def idistinv(self, u, n):
-
         alpha = self.alpha
         rho = self.rho
 
@@ -967,7 +892,6 @@ def discrete_chebyshev_recurrence_values(N, M):
     Chebyshev measure, the N-point discrete uniform measure with equispaced
     support on [0,1].
     """
-
     assert M > 0, N < M
 
     if N < 1:
@@ -1041,7 +965,6 @@ class DiscreteChebyshevPolynomials(OrthogonalPolynomialBasis1D):
         Optionally, add a nugget to ensure correct computation on the
         support points.
         """
-
         assert n >= 0
 
         x_standard = self.transform_to_standard.map(to_numpy_array(x))
@@ -1059,7 +982,6 @@ class DiscreteChebyshevPolynomials(OrthogonalPolynomialBasis1D):
         Computes the inverse order-n induced distribution at the locations
         u.
         """
-
         u = to_numpy_array(u)
         assert np.all(u >= 0), "Input u must contain numbers between 0 and 1"
         assert np.all(u <= 1), "Input u must contain numbers between 0 and 1"
@@ -1073,7 +995,7 @@ class DiscreteChebyshevPolynomials(OrthogonalPolynomialBasis1D):
             return discrete_chebyshev_idistinv_helper(u, self.support, self.idist(self.support, n[0], nugget=True))
 
         else:
-            nmax = np.amax(n)
+            nmax = int(np.amax(n))
             ind = np.digitize(n, np.arange(-0.5, 0.5+nmax+1e-8), right=False)
 
             for i in range(nmax+1):
@@ -1088,5 +1010,4 @@ class DiscreteChebyshevPolynomials(OrthogonalPolynomialBasis1D):
         (In this case, the "slow" routine is already very fast, so this
         is just an alias for idistinv.)
         """
-
         return self.idistinv(u, n)

--- a/UncertainSCI/opoly1d.py
+++ b/UncertainSCI/opoly1d.py
@@ -264,10 +264,7 @@ def markov_stiltjies(u, n, ab, supp):
     W[np.where(W > 1)] = 1  # Just in case for machine eps issues
     W[-1] = 1
 
-    if isinstance(u, float) or isinstance(u, int):
-        u = np.asarray([u])
-    else:
-        u = np.asarray(u)
+    u = np.atleast_1d(u)
 
     j = np.digitize(u, W, right=False)  # bins[i-1] <= x < bins[i], left bin end is open
     jleft = j - 1
@@ -299,19 +296,15 @@ def idistinv_driver(u, n, primitive, ab, supp):
     The ouptut x = F_n^{-1}(u)
 
     """
+    u = np.atleast_1d(u)
 
-    if isinstance(u, float) or isinstance(u, int):
-        u = np.asarray([u])
+    n = np.atleast_1d(n)
+    if n.size == 1:
+        intervals = markov_stiltjies(u, int(n[0]), ab, supp)
     else:
-        u = np.asarray(u)
-
-    if isinstance(n, np.int64):
-        intervals = markov_stiltjies(u, int(n), ab, supp)
-    elif isinstance(n, int):
-        intervals = markov_stiltjies(u, n, ab, supp)
-    else:
+        assert n.size == u.size
         intervals = np.zeros((n.size, 2))
-        nmax = max(n)
+        nmax = int(max(n))
         ind = np.digitize(n, np.arange(-0.5, 0.5+nmax+1e-8), right=False)
         for i in range(nmax+1):
             flags = ind == i+1
@@ -319,7 +312,7 @@ def idistinv_driver(u, n, primitive, ab, supp):
 
     x = np.zeros(u.size,)
     for j in range(u.size):
-        x[j] = optimize.bisect(lambda xx: primitive(xx) - u[j], intervals[j, 0], intervals[j, 1])
+        x[j] = optimize.bisect(lambda xx: np.asarray(primitive(xx)).item() - u[j], intervals[j, 0], intervals[j, 1])
 
     return x
 
@@ -477,11 +470,8 @@ class OrthogonalPolynomialBasis1D:
         #
         # Returns a numel(x) x numel(n) x numel(d) array.
 
-        n = np.asarray(n)
-        if isinstance(x, int) or isinstance(x, float):
-            x = np.asarray([x])
-        else:
-            x = np.asarray(x)
+        n = np.atleast_1d(n)
+        x = np.atleast_1d(x)
 
         if n.size < 1 or x.size < 1:
             return np.zeros(0)
@@ -792,13 +782,9 @@ class OrthogonalPolynomialBasis1D:
 
         The output is a x.size x n.size array.
         """
+        n = np.atleast_1d(n)
 
-        n = np.asarray(n)
-
-        if isinstance(x, float) or isinstance(x, int):
-            x = np.asarray([x])
-        else:
-            x = np.asarray(x)
+        x = np.atleast_1d(x)
 
         if n.size < 1 or x.size < 1:
             return np.zeros(0)
@@ -826,13 +812,9 @@ class OrthogonalPolynomialBasis1D:
 
         Need {a_k, b_k} k up to n
         """
+        n = np.atleast_1d(n)
 
-        n = np.asarray(n)
-
-        if isinstance(x, float) or isinstance(x, int):
-            x = np.asarray([x])
-        else:
-            x = np.asarray(x)
+        x = np.atleast_1d(x)
 
         nmax = np.max(n)
         ab = self.recurrence(nmax+1)

--- a/UncertainSCI/utils/casting.py
+++ b/UncertainSCI/utils/casting.py
@@ -5,8 +5,4 @@ def to_numpy_array(inp):
     """
     Converts floats into numpy arrays.
     """
-
-    if isinstance(inp, float) or isinstance(inp, int):
-        return np.asarray([inp])
-    else:
-        return np.asarray(inp)
+    return np.atleast_1d(inp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 matplotlib>=3.1.3
-numpy>=1.22
+numpy>=1.25
 scipy>=1.4.1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     url=r'https://sci.utah.edu/sci-software/simulation/uncertainsci.html',
     install_requires=[
         "matplotlib>=3.1.3",
-        "numpy>=1.22",
+        "numpy>=1.25",
         "scipy>=1.4.1"
     ]
     )

--- a/tests/test_jacobipolys.py
+++ b/tests/test_jacobipolys.py
@@ -24,7 +24,7 @@ class JacobiTestCase(unittest.TestCase):
         beta = -1. + 10*np.random.rand(1)[0]
         J = JacobiPolynomials(alpha=alpha, beta=beta)
 
-        N = int(np.ceil(60*np.random.rand(1)))
+        N = int(np.ceil(60*np.random.rand()))
         x = (1 + 5*np.random.rand(1)) * (1 + np.random.rand(50))
         y = (1 + 5*np.random.rand(1)) * (-1 - np.random.rand(50))
         x = np.concatenate([x, y])
@@ -53,7 +53,7 @@ class JacobiTestCase(unittest.TestCase):
         beta = -1. + 10*np.random.rand(1)[0]
 
         J = JacobiPolynomials(alpha=alpha, beta=beta)
-        N = int(np.ceil(60*np.random.rand(1)))
+        N = int(np.ceil(60*np.random.rand()))
 
         x, w = J.gauss_quadrature(N)
         w /= w.sum()    # Force probability measure
@@ -89,7 +89,8 @@ class IDistTestCase(unittest.TestCase):
         F2 = np.zeros(F1.shape)
         for xind, xval in enumerate(x):
             yquad = (y+1)/2.*(xval+1) - 1.
-            F2[xind] = np.dot(w, J.eval(yquad, n)**2) * (xval+1)/2
+            integral = np.dot(w, J.eval(yquad, n)**2) * (xval+1)/2
+            F2[xind] = np.asarray(integral).item()
 
         self.assertAlmostEqual(np.linalg.norm(F1-F2, ord=np.inf), 0.)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,8 +16,8 @@ class ModelTestCase(unittest.TestCase):
     def test_genz_oscillatory(self):
         """ Genz oscillatory model.  """
 
-        d = int(np.ceil(10*np.random.random(1)))
-        N = int(np.ceil(100*np.random.random(1)))
+        d = int(np.ceil(10*np.random.random()))
+        N = int(np.ceil(100*np.random.random()))
 
         # Function inputs
         p = np.random.randn(N, d)

--- a/tests/test_polys.py
+++ b/tests/test_polys.py
@@ -47,7 +47,7 @@ class PolysTestCase(unittest.TestCase):
         beta = 10*np.random.rand(dim)[0]
 
         N = np.random.randint(5, 10)
-        Inds = LpSet(dim=dim, order=N-1, p=np.Inf)
+        Inds = LpSet(dim=dim, order=N-1, p=np.inf)
 
         J = [None,]*dim
         for q in range(dim):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -16,8 +16,8 @@ class AffineMapTestCase(unittest.TestCase):
     def test_map(self):
         """ Forward affine map. """
 
-        d = int(np.ceil(10*np.random.random(1)))
-        N = int(np.ceil(100*np.random.random(1)))
+        d = int(np.ceil(10*np.random.random()))
+        N = int(np.ceil(100*np.random.random()))
 
         domain = np.random.randn(2, d)
         image = np.random.randn(2, d)
@@ -44,8 +44,8 @@ class AffineMapTestCase(unittest.TestCase):
     def test_mapinv(self):
         """ Inverse affine map. """
 
-        d = int(np.ceil(10*np.random.random(1)))
-        N = int(np.ceil(100*np.random.random(1)))
+        d = int(np.ceil(10*np.random.random()))
+        N = int(np.ceil(100*np.random.random()))
 
         domain = np.random.randn(2, d)
         image = np.random.randn(2, d)


### PR DESCRIPTION
This PR includes many small changes to the tests to ensure numpy >= 2 compatibility.  In particular, this PR addresses:
- warnings/errors resulting from casting arrays ndim > 0 to scalar
- some small name changes in numpy 2
    - e.g., np.Inf (which was always an alias for np.inf) was removed

Some items remaining to be considered:
- [x] Update requirements.txt and config.py to some version of numpy >= 2
- [x] Consider removing UncertainSCI.utils.version
    - The version module appears to only be used to verify numpy version >= 1.17, but I haven't thoroughly investigated this yet.
    - Regardless of where this module is used, I'm of the belief that this type of version checking/validation should be left to the package manager (pip or conda).
    - This also lets us (minorly) simplify the code interface because we don't have the implement two versions of our code for the quirks of our dependencies, though in practice I've only seen this used in our code for choosing a particular implementation of np.choice.
